### PR TITLE
Update CONTRIBUTING & close 'development'

### DIFF
--- a/.github/CONTRIBUTING.md
+++ b/.github/CONTRIBUTING.md
@@ -52,11 +52,21 @@ For collaborators, this is a set of rules for branch naming that we follow.
 
 For contributors, this is a good way to know what is/isn't being worked on.
 
- - `master`: the current stable (deployed) version of the code.
- - `development`: active branch that all PRs get merged into - this will always be the next release.
+ - `master`: active branch that all PRs get merged into - the latest commit will not necessarily be stable. To checkout a stable
+ version of master, checkout a tagged commit.
  - `fix_n`: a branch where issue `n` is being fixed.
 
-Code cycle: `fix_n` => `development` => `master`
+Code cycle: `fix_n` => `master` => `master#vXX.XX.XX`
+
+## Versioning
+
+Versioning is handled through tagged commits as opposed to separate branches for now.
+
+ - Release versions will follow [semver](http://semver.org/).
+ - Once a release occurs, that release will no longer be actively maintained and
+ you must update to the next patch release for bug fixes.
+ - All versions past 1.0 are considered stable.
+ - The latest tagged release will also be the deployed release.
 
 ## Modification of Dependencies
 


### PR DESCRIPTION
## Description

Updates contribution guide to reflect the issue below.

## Motivation and Context

In the first version of the contribution guide, I suggested that we use a branch named `development` for our unstable version and `master` for the stable latest release. But I just realized that Github only closes issues on PRs & commits if those commits are in the `master` branch.

Due to this, and to simplify development, I am suggesting we use tagged commits for this instead. The steps required for this are as follows:

 1. Merge this PR into `development`.
 2. Merge development into `master`.
 3. Change the PR base to `master` instead of `development` for open PRs.
 4. Close `development`.

When we are prepared to do releases, we can simply have a commit that updates all files that need version numbers (i.e. `package.json`) and tag that commit with a valid semver version number starting with `0.0.1`.

## How Has This Been Tested?

N/a.

## Screenshots (if appropriate):

N/a.

## Types of changes

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [x] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:

- [x] My code follows the [guidelines](CONTRIBUTING.md) of this project.
- [x] My change requires a change to the documentation.
- [x] I have updated the documentation accordingly.